### PR TITLE
Downloading requires the GPG key

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -25,9 +25,10 @@ define hashicorp::download (
   $binfile = "${name}_${version}/${name}"
 
   exec { "download ${name} ${version}":
-    command     => "/usr/local/bin/hashicorp-download.sh ${cache_dir} ${name} ${version} ${_os} ${_arch}",
-    path        => ['/bin', '/usr/bin'],
-    creates     => "${cache_dir}/${name}_${version}/${name}",
+    command => "/usr/local/bin/hashicorp-download.sh ${cache_dir} ${name} ${version} ${_os} ${_arch}",
+    path    => ['/bin', '/usr/bin'],
+    creates => "${cache_dir}/${name}_${version}/${name}",
+    require => Gnupg_key['hashicorp'],
   }
 
   file { "${install_dir}/${name}-${version}":


### PR DESCRIPTION
This commit makes sure the Hashicorp key exists on the system before
downloading files.

Without this "require" parameter, there are chances that the hashicorp
key does not exist yet on the machine, thus failing the Puppet run.